### PR TITLE
Typed pattern properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-json-schema",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/src/schema",
   "typings": "lib/src/schema",

--- a/src/object.ts
+++ b/src/object.ts
@@ -3,14 +3,21 @@ import { Schema, JSONObject, AnyJSON } from "./schema";
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 export type AnyRequired<K extends string> = {[P in K]: AnyJSON }
 
-export class ObjectSchema<P extends AnyRequired<keyof P>, K extends string, A extends JSONObject, PatternProperties, Dependencies>
-    extends Schema<AnyRequired<Diff<K, keyof P>> //additional required properties typed with any
-                   & Partial<Pick<P, Diff<keyof P, K>>> // properties not specified by requiredProperties
-                   & Pick<P, Diff<keyof P, Diff<keyof P, K>>> // required properties
-                   & A // additional properties
-                   & PatternProperties
-                   & Dependencies
-                  >  {
+export class ObjectSchema<
+      PropertyDefinitions extends AnyRequired<keyof PropertyDefinitions>,
+      RequiredProperties extends string,
+      AdditionalProperties extends JSONObject,
+      PatternProperties,
+      Dependencies
+    >
+    extends Schema<
+      AnyRequired<Diff<RequiredProperties, keyof PropertyDefinitions>> //additional required properties typed with any
+      & Partial<Pick<PropertyDefinitions, Diff<keyof PropertyDefinitions, RequiredProperties>>> // properties not specified by requiredProperties
+      & Pick<PropertyDefinitions, Diff<keyof PropertyDefinitions, Diff<keyof PropertyDefinitions, RequiredProperties>>> // required properties
+      & AdditionalProperties // additional properties
+      & PatternProperties
+      & Dependencies
+    >  {
   constructor () {
     super({ type: 'object' })
   }
@@ -28,15 +35,15 @@ export class ObjectSchema<P extends AnyRequired<keyof P>, K extends string, A ex
       acc[key] = properties[key].props
       return acc
     }, {})
-    return this.setProps({ properties: props }) as any as ObjectSchema<O, never, A, PatternProperties, Dependencies>
+    return this.setProps({ properties: props }) as any as ObjectSchema<O, RequiredProperties, AdditionalProperties, PatternProperties, Dependencies>
   }
 
   required <K extends string> (...required: K[]) {
-    return this.setProps({ required }) as any as ObjectSchema<P, K, A, PatternProperties, Dependencies>
+    return this.setProps({ required }) as any as ObjectSchema<PropertyDefinitions, K, AdditionalProperties, PatternProperties, Dependencies>
   }
 
   additionalProperties (additionalProperties: true): this
-  additionalProperties (additionalProperties: false): ObjectSchema<P, K, {}, PatternProperties, Dependencies>
+  additionalProperties (additionalProperties: false): ObjectSchema<PropertyDefinitions, RequiredProperties, {}, PatternProperties, Dependencies>
   additionalProperties (additionalProperties: boolean) {
     return this.setProps({ additionalProperties })
   }
@@ -46,7 +53,7 @@ export class ObjectSchema<P extends AnyRequired<keyof P>, K extends string, A ex
       acc[key] = patternProperties[key].props
       return acc
     }, {})
-    return this.setProps({ patternProperties: props }) as any as ObjectSchema<P, K, A, {[key: string]: AnyJSON }, Dependencies>
+    return this.setProps({ patternProperties: props }) as any as ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, {[key: string]: AnyJSON }, Dependencies>
   }
 
   dependencies (dependencies: {[key: string]: Schema<AnyJSON> | string[]}) {
@@ -59,7 +66,7 @@ export class ObjectSchema<P extends AnyRequired<keyof P>, K extends string, A ex
       }
       return acc
     }, {})
-    return this.setProps({ dependencies: props }) as any as ObjectSchema<P, K, A, PatternProperties, {[key: string]: AnyJSON}>
+    return this.setProps({ dependencies: props }) as any as ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, PatternProperties, {[key: string]: AnyJSON}>
   }
 
 }

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,21 +1,22 @@
 import { Schema, JSONObject, AnyJSON } from "./schema";
 
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
-export type AnyRequired<K extends string> = {[P in K]: AnyJSON }
+export type AnyRequired<T extends AnyJSON, K extends string> = {[P in K]: AnyJSON }
 
 export class ObjectSchema<
-      PropertyDefinitions extends AnyRequired<keyof PropertyDefinitions>,
+      PropertyDefinitions extends AnyRequired<AnyJSON, keyof PropertyDefinitions>,
       RequiredProperties extends string,
       AdditionalProperties extends JSONObject,
-      PatternProperties,
-      Dependencies
+      PatternPropertyValue extends AnyJSON,
+      PatternProperties extends {[key: string]: PatternPropertyValue},
+      Dependencies extends JSONObject
     >
     extends Schema<
-      AnyRequired<Diff<RequiredProperties, keyof PropertyDefinitions>> //additional required properties typed with any
+      & AnyRequired<PatternPropertyValue, Diff<RequiredProperties, keyof PropertyDefinitions>> //required properties which don't have a specified type:
       & Partial<Pick<PropertyDefinitions, Diff<keyof PropertyDefinitions, RequiredProperties>>> // properties not specified by requiredProperties
       & Pick<PropertyDefinitions, Diff<keyof PropertyDefinitions, Diff<keyof PropertyDefinitions, RequiredProperties>>> // required properties
-      & AdditionalProperties // additional properties
-      & PatternProperties
+      & AdditionalProperties
+      & Partial<PatternProperties>
       & Dependencies
     >  {
   constructor () {
@@ -35,28 +36,59 @@ export class ObjectSchema<
       acc[key] = properties[key].props
       return acc
     }, {})
-    return this.setProps({ properties: props }) as any as ObjectSchema<O, RequiredProperties, AdditionalProperties, PatternProperties, Dependencies>
+    return this.setProps({ properties: props }) as any as ObjectSchema<O, RequiredProperties, AdditionalProperties, PatternPropertyValue, PatternProperties, Dependencies>
   }
 
   required <K extends string> (...required: K[]) {
-    return this.setProps({ required }) as any as ObjectSchema<PropertyDefinitions, K, AdditionalProperties, PatternProperties, Dependencies>
+    return this.setProps({ required }) as any as ObjectSchema<PropertyDefinitions, K, AdditionalProperties, PatternPropertyValue, PatternProperties, Dependencies>
   }
 
   additionalProperties (additionalProperties: true): this
-  additionalProperties (additionalProperties: false): ObjectSchema<PropertyDefinitions, RequiredProperties, {}, PatternProperties, Dependencies>
+  additionalProperties (additionalProperties: false): ObjectSchema<PropertyDefinitions, RequiredProperties, {}, PatternPropertyValue, PatternProperties, Dependencies>
   additionalProperties (additionalProperties: boolean) {
     return this.setProps({ additionalProperties })
   }
 
-  patternProperties (patternProperties: {[key: string]: Schema<AnyJSON>}) {
-    const props = Object.keys(patternProperties).reduce<JSONObject>((acc, key) => {
-      acc[key] = patternProperties[key].props
+  patternProperties <T1 extends AnyJSON, Values extends T1>
+    (k1: RegExp, t1: Schema<T1>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, Values extends T1 | T2>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, Values extends T1 | T2 | T3>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, Values extends T1 | T2 | T3 | T4>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>,)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, T5 extends AnyJSON, Values extends T1 | T2 | T3 | T4 | T5>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>, k5: RegExp, t5: Schema<T5>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, T5 extends AnyJSON, T6 extends AnyJSON, Values extends T1 | T2 | T3 | T4 | T5 | T6>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>, k5: RegExp, t5: Schema<T5>, k6: RegExp, t6: Schema<T6>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, T5 extends AnyJSON, T6 extends AnyJSON, T7 extends AnyJSON, Values extends T1 | T2 | T3 | T4 | T5 | T6 | T7>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>, k5: RegExp, t5: Schema<T5>, k6: RegExp, t6: Schema<T6>, k7: RegExp, t7: Schema<T7>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, T5 extends AnyJSON, T6 extends AnyJSON, T7 extends AnyJSON, T8 extends AnyJSON, Values extends T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>, k5: RegExp, t5: Schema<T5>, k6: RegExp, t6: Schema<T6>, k7: RegExp, t7: Schema<T7>, k8: RegExp, t8: Schema<T8>, k9: RegExp)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T1 extends AnyJSON, T2 extends AnyJSON, T3 extends AnyJSON, T4 extends AnyJSON, T5 extends AnyJSON, T6 extends AnyJSON, T7 extends AnyJSON, T8 extends AnyJSON, T9 extends AnyJSON, Values extends T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>
+    (k1: RegExp, t1: Schema<T1>, k2: RegExp, t2: Schema<T2>, k3: RegExp, t3: Schema<T3>, k4: RegExp, t4: Schema<T4>, k5: RegExp, t5: Schema<T5>, k6: RegExp, t6: Schema<T6>, k7: RegExp, t7: Schema<T7>, k8: RegExp, t8: Schema<T8>, k9: RegExp, t9: Schema<T9>)
+    : ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, Values, {[key: string]: Values}, Dependencies>
+  patternProperties <T extends AnyJSON>(...args: (RegExp | Schema<AnyJSON>)[]): ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, AnyJSON, JSONObject, Dependencies>
+  patternProperties <T extends AnyJSON>(...args: (RegExp | Schema<AnyJSON>)[]) {
+    const props = args.filter(x => x instanceof RegExp).map((x: RegExp) => x.source).reduce<JSONObject>((acc, key, i) => {
+      const schema = args[i * 2 + 1]
+      if (schema instanceof Schema) {
+        acc[key] = schema.props
+      }
       return acc
     }, {})
-    return this.setProps({ patternProperties: props }) as any as ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, {[key: string]: AnyJSON }, Dependencies>
+    return this.setProps({ patternProperties: props }) as any
   }
 
-  dependencies (dependencies: {[key: string]: Schema<AnyJSON> | string[]}) {
+  dependencies (dependencies: {[key: string]: Schema<AnyJSON> | string[]}): ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, PatternPropertyValue, PatternProperties, JSONObject> {
     const props = Object.keys(dependencies).reduce<JSONObject>((acc, key) => {
       const value = dependencies[key]
       if (Array.isArray(value)) {
@@ -66,7 +98,7 @@ export class ObjectSchema<
       }
       return acc
     }, {})
-    return this.setProps({ dependencies: props }) as any as ObjectSchema<PropertyDefinitions, RequiredProperties, AdditionalProperties, PatternProperties, {[key: string]: AnyJSON}>
+    return this.setProps({ dependencies: props }) as any
   }
 
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -30,7 +30,7 @@ export class Schema<T extends AnyJSON> {
   type(type: 'boolean'): BooleanSchema
   type(type: 'null'): NullSchema
   type(type: 'array'): ArraySchema<any>
-  type(type: 'object'): ObjectSchema<JSONObject, never, JSONObject, {}, {}>
+  type(type: 'object'): ObjectSchema<{}, never, JSONObject, JSONObject, {}, {}>
   type (type: string) {
     if (type === 'string') {
       return new StringSchema()
@@ -51,7 +51,7 @@ export class Schema<T extends AnyJSON> {
       return new ArraySchema<any[]>()
     }
     if (type === 'object') {
-      return new ObjectSchema<{[x: string]: any}, never, {[x: string]: any}, {}, {}>()
+      return new ObjectSchema<{}, never, JSONObject, JSONObject, {}, {}>()
     }
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -20,6 +20,7 @@ import {
 function expectSchema <ExpectedType extends AnyJSON> (schema: Schema<ExpectedType>) {
   return expect(schema.toJSON())
 }
+function expectSchemaProperty<Z extends Schema<any>, K extends keyof Z['_T'], ExpectedType extends Z['_T'][K]> () {}
 
 describe('JSON schema', () => {
   it('should create a number schema', () => {
@@ -202,39 +203,46 @@ describe('JSON schema', () => {
 
   it('should create an object schema', () => {
     const objectSchema = schema.type('object')
-  
-    expectSchema<{}>(objectSchema).to.eql({
+    
+    expectSchemaProperty<typeof objectSchema, 'foo', AnyJSON>()
+    expectSchema(objectSchema).to.eql({
       type: 'object'
     })
   
     const minMaxProperties = object.maxProperties(3).minProperties(1)
 
-    expectSchema<{}>(minMaxProperties).to.eql({
+    expectSchema(minMaxProperties).to.eql({
       type: 'object',
       maxProperties: 3,
       minProperties: 1
     })
 
     const schemaWithProperties = object({
-        a: string,
-        b: array(number)
-      })
+      a: string,
+      b: array(number)
+    })
 
-    expectSchema<{ a?: string, b?: number[] }>(schemaWithProperties).to.eql({
+    expectSchemaProperty<typeof schemaWithProperties, 'a', string | undefined>()
+    expectSchemaProperty<typeof schemaWithProperties, 'b', number[] | undefined>()
+    expectSchema(schemaWithProperties).to.eql({
       type: 'object',
       properties: {
         a: { type: 'string' },
         b: { type: 'array', items: { type: 'number' }}
       }
     })
-    
+
     const schemaWithRequiredProperties = object({
         a: string,
         b: array(number)
       })
       .required('a', 'b', 'c')
 
-    expectSchema<{ a: string, b: number[], c: AnyJSON, someOtherProperty?: string }>(schemaWithRequiredProperties).to.eql({
+    expectSchemaProperty<typeof schemaWithRequiredProperties, 'a', string>()
+    expectSchemaProperty<typeof schemaWithRequiredProperties, 'b', number[]>()
+    expectSchemaProperty<typeof schemaWithRequiredProperties, 'c', AnyJSON>()
+    expectSchemaProperty<typeof schemaWithRequiredProperties, 'someOtherProperty', AnyJSON>()
+    expectSchema(schemaWithRequiredProperties).to.eql({
       type: 'object',
       properties: {
         a: { type: 'string' },
@@ -245,35 +253,56 @@ describe('JSON schema', () => {
     
     const schemaWithNoAdditionalProperties = object.required('a', 'b', 'c').properties({
         a: string,
-        b: array(number)
+        b: array(number),
+        d: boolean
       })
       .additionalProperties(false)
 
-    expectSchema<{ a: string, b: number[], c: AnyJSON }>(schemaWithNoAdditionalProperties).to.eql({
+    expectSchemaProperty<typeof schemaWithNoAdditionalProperties, 'a', string >()
+    expectSchemaProperty<typeof schemaWithNoAdditionalProperties, 'b', number[] >()
+    expectSchemaProperty<typeof schemaWithNoAdditionalProperties, 'c', AnyJSON >()
+    expectSchemaProperty<typeof schemaWithNoAdditionalProperties, 'd', boolean | undefined>()
+    expectSchema(schemaWithNoAdditionalProperties).to.eql({
       type: 'object',
       properties: {
         a: { type: 'string' },
-        b: { type: 'array', items: { type: 'number' }}
+        b: { type: 'array', items: { type: 'number' }},
+        d: { type: 'boolean' }
       },
       required: ['a', 'b', 'c'],
       additionalProperties: false
     })
 
-    const objectWithPatternProperties = object({
-        a: string
-      })
-      .patternProperties({
-        "$foo^": string,
-        "$bar^": number
-      })
-      .additionalProperties(false)
-      
+    const objectWithPatternProperties = object
+    .patternProperties(
+      /$foo^/, string,
+      /$bar^/, number
+    )
+    .additionalProperties(false)
 
+    expectSchemaProperty<typeof objectWithPatternProperties, 'a', string | number | undefined>()
     expectSchema(objectWithPatternProperties).to.eql({
       type: 'object',
-      properties: {
-        a: { type: 'string' },
-      },
+      additionalProperties: false,
+      patternProperties: {
+        "$foo^": { type: 'string' },
+        "$bar^": { type: 'number' }
+      }
+    })
+    const objectWithRequiredPatternProperties = object
+      .patternProperties(
+        /$foo^/, string,
+        /$bar^/, number
+      )
+      .required('a')
+      .additionalProperties(false)
+    
+
+    expectSchemaProperty<typeof objectWithRequiredPatternProperties, 'a', string | number>()
+    expectSchemaProperty<typeof objectWithRequiredPatternProperties, 'b', string | number | undefined>()
+    expectSchema(objectWithRequiredPatternProperties).to.eql({
+      type: 'object',
+      required: ['a'],
       additionalProperties: false,
       patternProperties: {
         "$foo^": { type: 'string' },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -243,11 +243,10 @@ describe('JSON schema', () => {
       required: ['a', 'b', 'c']
     })
     
-    const schemaWithNoAdditionalProperties = object({
+    const schemaWithNoAdditionalProperties = object.required('a', 'b', 'c').properties({
         a: string,
         b: array(number)
       })
-      .required('a', 'b', 'c')
       .additionalProperties(false)
 
     expectSchema<{ a: string, b: number[], c: AnyJSON }>(schemaWithNoAdditionalProperties).to.eql({


### PR DESCRIPTION
* Rename types in `ObjectSchema` to be more clear
* add better types for pattern properties - requires use of varargs for pattern properties. [BREAKING CHANGE]