### PR TITLE
Emit schema instances in decorator metadata

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -194,7 +194,7 @@ interface Validator<T> {
 
 interface Schema<S extends JsonSchemaInput> extends Validator<TypeOf<S>> {
   _SchemaNodeOf: SchemaNodeOf<S>
- }
+}
 
 export function schema<S extends JsonSchemaInput>(schema: S, options?: Ajv.Options): Schema<S> {
   const expectedSchema = preProcessSchema(schema),

--- a/index.ts
+++ b/index.ts
@@ -192,16 +192,15 @@ interface Validator<T> {
   toJSON(): string
 }
 
-interface Schema<S extends JsonSchemaInput> extends Validator<TypeOf<S>> {
+export interface Schema<S extends JsonSchemaInput> extends Validator<TypeOf<S>> {
   _SchemaNodeOf: SchemaNodeOf<S>
+  new (...args: any[]): never
 }
 
 export function schema<S extends JsonSchemaInput>(schema: S, options?: Ajv.Options): Schema<S> {
   const expectedSchema = preProcessSchema(schema),
     validate = new Ajv(options).compile(expectedSchema)
   return {
-    _SchemaNodeOf: null as any as SchemaNodeOf<S>,
-
     validate(input: any) {
       const valid = validate(input)
       if (valid) {
@@ -215,7 +214,7 @@ export function schema<S extends JsonSchemaInput>(schema: S, options?: Ajv.Optio
     toJSON() {
       return expectedSchema
     }
-  }
+  } as Schema<S>
 }
 
 export const Struct = <Properties extends {readonly [key: string]: JsonSchemaInput }, OptionalKeys extends string> (properties: Properties, options: { optional?: OptionalKeys[], description?: string } = {}) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,18 @@
         "picomatch": "^2.0.4"
       }
     },
+    "reflect-annotations": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/reflect-annotations/-/reflect-annotations-2.6.0.tgz",
+      "integrity": "sha512-FjFcAXRIez2ZeTMOIjghp+gbkNHL2ua/BQ48nt+8+ygB8FMG7ziOhytV7doL8XF4ExWfo98H8IMHfEndAXI/Jg==",
+      "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@types/mocha": "5.2.7",
     "@types/node": "13.1.6",
     "mocha": "7.0.0",
+    "reflect-annotations": "^2.6.0",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.0",
     "ts-node": "8.6.1",
     "typescript": "3.7.4",

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -98,7 +98,7 @@ describe('decorator metadata', () => {
       method (thing: Thing) {}
     }
     const annotations = reflectAnnotations(SomeClass)
-    assertNotEqual(annotations[0]?.types?.parameters?.slice().pop(), Object)
+    assertEqual(annotations[0]?.types?.parameters?.slice().pop(), Thing)
   })
 })
 

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -1,5 +1,6 @@
 import { schema, Struct } from ".."
-import { deepStrictEqual as assertEqual } from 'assert'
+import { reflectAnnotations, createAnnotationFactory } from "reflect-annotations";
+import { deepStrictEqual as assertEqual, notEqual as assertNotEqual} from 'assert'
 
 describe('schema', () => {
   describe('validation', () => {
@@ -76,6 +77,28 @@ describe('schema', () => {
         }
       })
     })
+  })
+})
+
+describe('decorator metadata', () => {
+  it('should emit decorator metadata at compile time', () => {
+    const Thing = schema({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string'
+        }
+      },
+      required: ['name']
+    } as const)
+    type Thing = schema<typeof Thing>
+    const Random = createAnnotationFactory(class {})
+    class SomeClass {
+      @Random()
+      method (thing: Thing) {}
+    }
+    const annotations = reflectAnnotations(SomeClass)
+    assertNotEqual(annotations[0]?.types?.parameters?.slice().pop(), Object)
   })
 })
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["es2018"],
     "strict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
-  },
-  "include": ["index.ts"]
+  }
 }


### PR DESCRIPTION
Not sure what the hack was for getting typescript to emit the right metadata..
So I added a failing test!